### PR TITLE
Fix bracket matching in tfvars

### DIFF
--- a/languages/hcl/brackets.scm
+++ b/languages/hcl/brackets.scm
@@ -3,3 +3,4 @@
 ("{" @open "}" @close)
 ((block_start) @open (block_end) @close)
 ((tuple_start) @open (tuple_end) @close)
+((object_start) @open (object_end) @close)

--- a/languages/terraform-vars/brackets.scm
+++ b/languages/terraform-vars/brackets.scm
@@ -3,3 +3,4 @@
 ("{" @open "}" @close)
 ((block_start) @open (block_end) @close)
 ((tuple_start) @open (tuple_end) @close)
+((object_start) @open (object_end) @close)

--- a/languages/terraform/brackets.scm
+++ b/languages/terraform/brackets.scm
@@ -3,3 +3,4 @@
 ("{" @open "}" @close)
 ((block_start) @open (block_end) @close)
 ((tuple_start) @open (tuple_end) @close)
+((object_start) @open (object_end) @close)


### PR DESCRIPTION
In a tfvars file, a variable may be defined like so:

    my_var_object = {
        foo = "bar"
        baz = { .. }
    }

In such cases, the curly braces were not showing as matching, and motions like vim::Matching would fail to jump to the matching bracket.