### PR TITLE
Add `tofu` filename extension to `path_suffixes`

### DIFF
--- a/languages/terraform/config.toml
+++ b/languages/terraform/config.toml
@@ -1,6 +1,6 @@
 name = "Terraform"
 grammar = "hcl"
-path_suffixes = ["tf"]
+path_suffixes = ["tf", "tofu"]
 line_comments = ["# ", "// "]
 block_comment = ["/*", "*/"]
 autoclose_before = ",}])"


### PR DESCRIPTION
OpenTofu supports `.tofu` as a filename extension, so it’d be a nice minor quality-of-life improvement for this extension to automatically activate for such files.