### PR TITLE
Add comment syntax highlighting to HCL and Terraform

### DIFF
--- a/languages/hcl/injections.scm
+++ b/languages/hcl/injections.scm
@@ -4,3 +4,6 @@
   (template_literal) @injection.content
   (heredoc_identifier) @injection.language
   (#downcase! @injection.language))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/languages/terraform-vars/injections.scm
+++ b/languages/terraform-vars/injections.scm
@@ -7,3 +7,6 @@
 
 ; https://github.com/nvim-treesitter/nvim-treesitter/blob/ce4adf11cfe36fc5b0e5bcdce0c7c6e8fbc9798a/queries/terraform/injections.scm
 ; inherits: hcl
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/languages/terraform/injections.scm
+++ b/languages/terraform/injections.scm
@@ -7,3 +7,6 @@
 
 ; https://github.com/nvim-treesitter/nvim-treesitter/blob/ce4adf11cfe36fc5b0e5bcdce0c7c6e8fbc9798a/queries/terraform/injections.scm
 ; inherits: hcl
+
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Add `comment` _language_ support to Terraform. This will close out https://github.com/thedadams/zed-comment/issues/13