### PR TITLE
Use HCL grammar from tree-sitter-grammars

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -15,5 +15,5 @@ language_ids = { Terraform = "terraform", "Terraform Vars" = "terraform-vars" }
 code_action_kinds = []
 
 [grammars.hcl]
-repository = "https://github.com/MichaHoffmann/tree-sitter-hcl"
-commit = "e936d3fef8bac884661472dce71ad82284761eb1"
+repository = "https://github.com/tree-sitter-grammars/tree-sitter-hcl"
+commit = "fad991865fee927dd1de5e172fb3f08ac674d914"


### PR DESCRIPTION
The grammar used is 2 years outdated at this point and the language has since added bunch of features that break it (eg: custom functions syntax).

Also, the upstream now redirects to [tree-sitter-grammars/tree-sitter-hcl](https://github.com/tree-sitter-grammars/tree-sitter-hcl), the latest release there is v1.2.0 at commit `fad991865fee927dd1de5e172fb3f08ac674d914`.