### PR TITLE
Improve reference syntax highlighting

### DIFF
--- a/languages/hcl/highlights.scm
+++ b/languages/hcl/highlights.scm
@@ -108,9 +108,12 @@
 
 ; var.foo, data.bar
 ;
-; first element in get_attr is a variable.builtin or a reference to a variable.builtin
-(expression
+; The first step (`var`, `local`, `module`...) stays neutral, every
+; following step is highlighted, so that the meaningful part of a
+; reference stands out from its namespace.
+; @property is the conventional tree-sitter capture for a member access.
+(_
   (variable_expr
     (identifier) @variable)
   (get_attr
-    (identifier) @variable))
+    (identifier) @property))

--- a/languages/terraform-vars/highlights.scm
+++ b/languages/terraform-vars/highlights.scm
@@ -108,39 +108,45 @@
 
 ; var.foo, data.bar
 ;
-; first element in get_attr is a variable.builtin or a reference to a variable.builtin
-(expression
+; The first step (`var`, `local`, `module`...) stays neutral, every
+; following step is highlighted, so that the meaningful part of a
+; reference stands out from its namespace.
+; @property is the conventional tree-sitter capture for a member access.
+(_
   (variable_expr
     (identifier) @variable)
   (get_attr
-    (identifier) @variable))
+    (identifier) @property))
 
 ; https://github.com/nvim-treesitter/nvim-treesitter/blob/cb79d2446196d25607eb1d982c96939abdf67b8e/queries/terraform/highlights.scm
 ; Terraform specific references
 ;
 ;
-; local/module/data/var/output
-(expression
+; builtins
+;
+; Name the node correctly and give a hook for `experimental.theme_overrides`.
+(_
   (variable_expr
-    (identifier) @variable
-    (#any-of? @variable "data" "var" "local" "module" "output"))
-  (get_attr
-    (identifier) @variable))
+    (identifier) @variable.builtin
+    (#any-of? @variable.builtin "data" "var" "local" "module" "output" "count" "each" "self"))
+  (get_attr))
 
 ; path.root/cwd/module
-(expression
+(_
   (variable_expr
     (identifier) @type
     (#eq? @type "path"))
+  .
   (get_attr
     (identifier) @variable
     (#any-of? @variable "root" "cwd" "module")))
 
 ; terraform.workspace
-(expression
+(_
   (variable_expr
     (identifier) @type
     (#eq? @type "terraform"))
+  .
   (get_attr
     (identifier) @variable
     (#any-of? @variable "workspace")))

--- a/languages/terraform/highlights.scm
+++ b/languages/terraform/highlights.scm
@@ -108,39 +108,45 @@
 
 ; var.foo, data.bar
 ;
-; first element in get_attr is a variable.builtin or a reference to a variable.builtin
-(expression
+; The first step (`var`, `local`, `module`...) stays neutral, every
+; following step is highlighted, so that the meaningful part of a
+; reference stands out from its namespace.
+; @property is the conventional tree-sitter capture for a member access.
+(_
   (variable_expr
     (identifier) @variable)
   (get_attr
-    (identifier) @variable))
+    (identifier) @property))
 
 ; https://github.com/nvim-treesitter/nvim-treesitter/blob/cb79d2446196d25607eb1d982c96939abdf67b8e/queries/terraform/highlights.scm
 ; Terraform specific references
 ;
 ;
-; local/module/data/var/output
-(expression
+; builtins
+;
+; Name the node correctly and give a hook for `experimental.theme_overrides`.
+(_
   (variable_expr
-    (identifier) @variable
-    (#any-of? @variable "data" "var" "local" "module" "output"))
-  (get_attr
-    (identifier) @variable))
+    (identifier) @variable.builtin
+    (#any-of? @variable.builtin "data" "var" "local" "module" "output" "count" "each" "self"))
+  (get_attr))
 
 ; path.root/cwd/module
-(expression
+(_
   (variable_expr
     (identifier) @type
     (#eq? @type "path"))
+  .
   (get_attr
     (identifier) @variable
     (#any-of? @variable "root" "cwd" "module")))
 
 ; terraform.workspace
-(expression
+(_
   (variable_expr
     (identifier) @type
     (#eq? @type "terraform"))
+  .
   (get_attr
     (identifier) @variable
     (#any-of? @variable "workspace")))

--- a/languages/terraform/semantic_token_rules.json
+++ b/languages/terraform/semantic_token_rules.json
@@ -1,0 +1,12 @@
+// Extension-provided semantic token rules for Terraform.
+[
+  // Fix language server not separating `local` from `foo` in `local.foo`
+  // by handing reference steps to tree-sitter (no `style` field removes
+  // semantic styling).
+  { "token_type": "variable" },
+  // Style attribute names as `constant`, since the server types them
+  // `property`, which is the same style `highlights.scm` gives reference
+  // steps. This allows differentiating declaration `foo` from reference
+  // `var.foo` in `foo = var.foo`.
+  { "token_type": "property", "style": ["constant"] }
+]


### PR DESCRIPTION
# Improve reference syntax highlighting

## Observation

Syntax highlighting is missing on references (`var.foo`, `local.bar`, `data.aws_instance.this`, `module.my_module.output`), even when setting the `semantic_tokens` parameter to `combined`. This PR keeps the namespace (`var`, `local`, `module`, ...) neutral and colors the steps that follow, so that the informative part of a reference stands out from the part that repeats on every line.

It also fixes a pattern that never matched: references inside any operation, such as `local.enabled && var.foo`, were not highlighted at all.

### Examples

-  Without semantic tokens, highlighting is pretty minimal :

<img width="1708" height="1146" alt="image" src="https://github.com/user-attachments/assets/5af6cfec-b803-4131-ab73-fe2a220403d2" />

<img width="1958" height="696" alt="image" src="https://github.com/user-attachments/assets/20c523de-83ee-45b1-aff2-039dcc4f12ff" />

<img width="1828" height="873" alt="image" src="https://github.com/user-attachments/assets/7e77b69d-4f40-4149-8eec-31ac113ceae2" />

- With the `combined` mode, it is noticeably better with the left side of assignments turning red on One Dark. The issue is that references keep the default text color : the prefix (local, data, var) and the name it points to are painted alike, so nothing separates them.

<img width="1730" height="1155" alt="image" src="https://github.com/user-attachments/assets/1677caf6-717d-4d88-bde4-d2b2dc318ca2" />

<img width="1970" height="700" alt="image" src="https://github.com/user-attachments/assets/bb3380d3-2272-497c-a8e8-ee25512c7159" />

<img width="1932" height="876" alt="image" src="https://github.com/user-attachments/assets/9567fb16-20d1-40f8-8bc9-a66b2543b039" />

## The problem

The grammar captures both sides of a reference with the same name:

```scheme
(expression
  (variable_expr
    (identifier) @variable)
  (get_attr
    (identifier) @variable))
```

So `local` and `enabled` in `local.enabled` are indistinguishable, even though the tree separates them cleanly into `variable_expr` and `get_attr`.

For users who enable `semantic_tokens`, the language server takes over and the result is the same.
The server sends **one token per reference step**, and every step carries the same type with no modifier:

```
L  4:43  'local'      type=variable  mods=[]
L  4:49  'enabled'    type=variable  mods=[]
```

## Proposed fixes

### `@variable` -> `@property` on `get_attr` and `expression` -> `_`

The following allows differentiating the prefix from the rest of the reference. The prefix stays `@variable`, it keeps its neutral color and the rest gets colorized.

```diff
-(expression
+(_
   (variable_expr
     (identifier) @variable)
   (get_attr
-    (identifier) @variable))
+    (identifier) @property))
```

The parent becomes a wildcard (`_`) in order to match on any parent node. This fixes a bug for cases where the node is not a simple `expression`. For example, in `local.enabled && var.foo` it is a `binary_operation`. The original pattern therefore skipped every reference used inside an operation.

Illustration without the wildcard :

<img width="1499" height="462" alt="image" src="https://github.com/user-attachments/assets/bf3c6865-cbc6-449d-a7c5-2f31962aaa31" />

And with it :

<img width="1529" height="470" alt="image" src="https://github.com/user-attachments/assets/70a51190-6006-492a-8059-6d39a5604021" />

### Terraform-specific patterns

- The `data` / `var` / `local` / `module` / `output` pattern now captures the namespace as `@variable.builtin` and no longer captures the step after it. `@variable.builtin` falls back to `variable` in themes that do not define it, so the namespace stays neutral, while themes and `experimental.theme_overrides` gain a hook.
- `count`, `each` and `self` are added to that list.
- The `path.*` and `terraform.workspace` patterns get the same wildcard parent, plus a `.` anchor. The anchor stops them from pairing their prefix with a distant step: without it, `path.module == var.root` captures `root` as if it belonged to `path`.

### `semantic_token_rules.json`

This file only matters when the user enables `semantic_tokens` (which is `off` by default). Without it, the server repaints every reference step and the grammar change is invisible.

Added :

```json
[
  { "token_type": "variable" },
  { "token_type": "property", "style": ["constant"] }
]
```

The first rule disables semantic styling for the `variable` token type which allows the extension to differentiate `local` from `foo` in `local.foo`.

The second one exists because the server already types attribute declarations as `property`, which is the same label the grammar now gives reference steps. Without it, both sides of `foo = var.foo` would come out in the same color. This is purely a cosmetic decision which should be discussed before merging (cf next section).

#### Alternatives for the coloration

1. Other IDEs like JetBrains keep declaration and reference to be the same color.

Illustration :

<img width="813" height="260" alt="image" src="https://github.com/user-attachments/assets/667212b5-b923-4883-938d-35db8bd09e58" />

Removing the second rule in the `semantic_token_rules.json` files would have the same effect in Zed

- In default `semantic_tokens` mode :

<img width="1704" height="1226" alt="image" src="https://github.com/user-attachments/assets/88d6267c-ec96-4c64-acc6-259b8d1d937a" />

- In combined mode : a lot of red, just like we have a lot of purple in JetBrains

<img width="1725" height="1226" alt="image" src="https://github.com/user-attachments/assets/d9cfbe8e-be75-4f89-8c82-b6586d3d853d" />
 
2. With the changes in `semantic_token_rules.json` we can actually differentiate declaration from reference, which is what I implemented since I think it's a great addition but which is debatable :

- In default `semantic_tokens` it is the same as without the changes

- In combined mode, it gives the following result :

<img width="1720" height="1219" alt="image" src="https://github.com/user-attachments/assets/cb0c6123-4f04-45a9-b2c2-2280b3fa3f76" />

<img width="1967" height="666" alt="image" src="https://github.com/user-attachments/assets/d42aadcf-b456-4022-a72a-cd4f76b2b3c8" />

<img width="1914" height="861" alt="image" src="https://github.com/user-attachments/assets/71f85dc4-3307-461e-bd94-28080d93aa42" />

<img width="782" height="262" alt="image" src="https://github.com/user-attachments/assets/b4c0a0ce-b446-4d90-9e15-19acf7bf018a" />

3. Another option would be to capture the right side after the prefix as a `@constant`. That's a naming abuse but it wouldn't change the color of existing colored tokens for users in `semantic_tokens = "combined"` mode, only add a gold color to things that weren't colorized.

Here is how this third option would look like : 

<img width="1725" height="1232" alt="image" src="https://github.com/user-attachments/assets/5ccbc328-7927-484a-bc30-c74078b22a9c" />

---

I'll let you decide on which alternative you prefer !

| Alternative | `get_attr` capture | `semantic_token_rules.json` | Result in `combined` mode |
| --- | --- | --- | --- |
| **1** — JetBrains-like | `@property` | `[{ "token_type": "variable" }]` | references and declarations share the same red |
| **2** — implemented | `@property` | `[{ "token_type": "variable" }, { "token_type": "property", "style": ["constant"] }]` | references red, declarations gold |
| **3** — `@constant` | `@constant` | `[{ "token_type": "variable" }]` | references gold, declarations stay red |